### PR TITLE
support for modeloverwrites correct display of all Transforms

### DIFF
--- a/EditorCore/EditorForm.cs
+++ b/EditorCore/EditorForm.cs
@@ -375,6 +375,10 @@ namespace EditorCore
 			string PlaceholderModel = ModelsFolder + "\\" + GameModule.GetPlaceholderModel(obj.Name, listName);
 
 			string ModelFile = GetModelName(obj.ModelName);
+
+            if (ModelFile==null&&File.Exists(ModelsFolder + "\\" + obj.ModelName + ".obj"))
+                ModelFile = ModelsFolder + "\\" + obj.ModelName + ".obj";
+
             if (ModelFile == null) ModelFile = PlaceholderModel;
             render.AddModel(ModelFile, obj, obj.ModelView_Pos, obj.ModelView_Scale, obj.ModelView_Rot);
         }

--- a/FileFormatPlugins/KCLExt/KCL/KCL.cs
+++ b/FileFormatPlugins/KCLExt/KCL/KCL.cs
@@ -104,7 +104,7 @@ namespace Smash_Forge
         {
             public List<int> faces = new List<int>();
             public List<Vertex> vertices = new List<Vertex>();
-            public int[] Faces;
+            public List<Face> Faces = new List<Face>();
 
             // for drawing
             public int[] display;
@@ -116,6 +116,10 @@ namespace Smash_Forge
             public class Face
             {
                 public int MaterialFlag = 0;
+                
+                public Vertex vtx;
+                public Vertex vtx2;
+                public Vertex vtx3;
 
             }
 
@@ -309,6 +313,12 @@ namespace Smash_Forge
                     kclmodel.faces.Add(ft);
                     kclmodel.faces.Add(ft + 1);
                     kclmodel.faces.Add(ft + 2);
+
+                    face.vtx = vtx;
+                    face.vtx2 = vtx2;
+                    face.vtx3 = vtx3;
+
+                    kclmodel.Faces.Add(face);
 
                     ft += 3;
 

--- a/FileFormatPlugins/KCLExt/KCLext.cs
+++ b/FileFormatPlugins/KCLExt/KCLext.cs
@@ -3,6 +3,7 @@ using Smash_Forge;
 using Syroot.NintenTools.MarioKart8.Common;
 using System;
 using System.Collections.Generic;
+using System.Drawing;
 using System.IO;
 using System.Linq;
 using System.Text;
@@ -11,7 +12,7 @@ using System.Windows.Forms;
 
 namespace KCLExt
 {
-	class KCLExt : ExtensionManifest
+	public class KCLExt : ExtensionManifest
 	{
 		public string ModuleName => "KCL extension";
 
@@ -63,28 +64,77 @@ namespace KCLExt
 			OpenFileDialog opn = new OpenFileDialog();
 			if (opn.ShowDialog() != DialogResult.OK) return;
 			var kcl = new KCL(File.ReadAllBytes(opn.FileName));
-			using (System.IO.StreamWriter f = new System.IO.StreamWriter(opn.FileName + ".obj"))
-			{
-				int VertexOffest = 1;
-				foreach (var mod in kcl.models)
-				{
-					var vert = mod.vertices;
-					foreach (var v in vert)
-					{
-						f.WriteLine($"v {v.pos.X} {v.pos.Y} {v.pos.Z}"); //{v.col.X} {v.col.Y} {v.col.Z} for vertex colors
-						f.WriteLine($"vn {v.nrm.X} {v.nrm.Y} {v.nrm.Z}");
-					}
-					var disp = mod.display;
-					for (int i = 0; i < disp.Length;)
-					{
-						f.WriteLine(
-							$"f {disp[i] + VertexOffest}//{disp[i++] + VertexOffest} " +
-							  $"{disp[i] + VertexOffest}//{disp[i++] + VertexOffest} " +
-							  $"{disp[i] + VertexOffest}//{disp[i++] + VertexOffest}");
-					}
-					VertexOffest += vert.Count;
-				}
-			}
+
+            PublicFunctions.WriteObj(kcl,opn.FileName);
 		}
-	}
+
+        
+    }
+
+    public static class PublicFunctions
+    {
+        public static void WriteObj(KCL kcl, string fileName, List<Color> typeColors = null)
+        {
+            StreamWriter f = new System.IO.StreamWriter(fileName + ".obj");
+            StreamWriter fmat = new System.IO.StreamWriter(fileName + ".mtl");
+            f.WriteLine($"mtllib {fileName.Split('\\').Last()}.mtl");
+            int index = 0;
+
+            List<int> addedMaterials = new List<int>();
+
+            foreach (var mod in kcl.models)
+            {
+                f.WriteLine("o model" + index);
+
+                Dictionary<int, List<KCL.KCLModel.Face>> faces = new Dictionary<int, List<KCL.KCLModel.Face>>();
+
+                var vert = mod.vertices;
+                foreach (var v in vert)
+                {
+                    f.WriteLine($"v {v.pos.X} {v.pos.Y} {v.pos.Z}"); //{v.col.X} {v.col.Y} {v.col.Z} for vertex colors
+                    f.WriteLine($"vn {v.nrm.X} {v.nrm.Y} {v.nrm.Z}");
+                }
+
+                foreach (var face in mod.Faces)
+                {
+                    if (!faces.ContainsKey(face.MaterialFlag))
+                        faces[face.MaterialFlag] = new List<KCL.KCLModel.Face>();
+                    faces[face.MaterialFlag].Add(face);
+                }
+
+                int typeIndex = 0;
+                foreach (int type in faces.Keys)
+                {
+                    if (!addedMaterials.Contains(type))
+                    {
+                        fmat.WriteLine($"newmtl collision{typeIndex}");
+                        fmat.WriteLine("Ns 100");
+                        fmat.WriteLine("Ka 0.000000 0.000000 0.000000");
+                        fmat.WriteLine((typeColors != null) ? $"Kd {typeColors[type].R / 255.0} {typeColors[type].G / 255.0} {typeColors[type].B / 255.0}" : "Kd 1.000000 1.000000 1.000000");
+                        fmat.WriteLine("Ks 0.000000 0.000000 0.000000");
+                        fmat.WriteLine("Ke 0.000000 0.000000 0.000000");
+                        fmat.WriteLine("Ni 1.000000");
+                        fmat.WriteLine("d 1.000000");
+                        fmat.WriteLine("illum 2");
+                        addedMaterials.Add(type);
+                    }
+
+                    f.WriteLine("usemtl collision" + typeIndex);
+                    foreach (KCL.KCLModel.Face face in faces[type])
+                    {
+                        f.WriteLine(
+                        $"f {vert.IndexOf(face.vtx) + 1} " +
+                          $"{vert.IndexOf(face.vtx2) + 1} " +
+                          $"{vert.IndexOf(face.vtx3) + 1}");
+                    }
+                    typeIndex++;
+                }
+
+                index++;
+            }
+
+            f.Close();
+            fmat.Close();
+        }
+    }
 }

--- a/ModelViewer/RendererControl.xaml.cs
+++ b/ModelViewer/RendererControl.xaml.cs
@@ -168,13 +168,15 @@ namespace ModelViewer
             else Model = ImportedModels[path];
             Model.Transform = new RotateTransform3D(new AxisAngleRotation3D(new Vector3D(1, 0, 0), 90));
             Models[obj].Content = Model;
-            Transform3DGroup t = new Transform3DGroup();
-            t.Children.Add(new RotateTransform3D(new AxisAngleRotation3D(new Vector3D(1, 0, 0), rot.X)));
-            t.Children.Add(new RotateTransform3D(new AxisAngleRotation3D(new Vector3D(0, 1, 0), rot.Y)));
-            t.Children.Add(new RotateTransform3D(new AxisAngleRotation3D(new Vector3D(0, 0, 1), rot.Z)));
-            t.Children.Add(new ScaleTransform3D(scale));
-            t.Children.Add(new TranslateTransform3D(pos));
-            Models[obj].Transform = t;
+
+            Matrix3D m = Matrix3D.Identity;
+            m.Scale(scale);
+            m.Rotate(new Quaternion(new Vector3D(1, 0, 0), rot.X));
+            m.Rotate(new Quaternion(new Vector3D(0, 0, 1), rot.Z));
+            m.Rotate(new Quaternion(new Vector3D(0, 1, 0), rot.Y));
+            m.Translate(pos);
+
+            Models[obj].Transform = new MatrixTransform3D(m);
         }
 
         public void RemoveModel(dynamic obj)


### PR DESCRIPTION
model overwrites can fetch some accurate AreaModels from the baseModels, also the Transformations now use a custom Matrix made for showing object with nintendos Transforms correctly, also collision support now allows per type material colors