### PR TITLE
BfresConverter: Convert all models in a BFRES

### DIFF
--- a/EditorCore/EditorForm.cs
+++ b/EditorCore/EditorForm.cs
@@ -386,7 +386,7 @@ namespace EditorCore
 			string CachedModelPath = $"{ModelsFolder}\\{ObjName}.obj";
 			if (render.ImportedModels.ContainsKey(CachedModelPath) || //The model has aready been loaded or has been converted
 				File.Exists(CachedModelPath) ||
-				GameModule.ConvertModelFile(ObjName, CachedModelPath))
+				GameModule.ConvertModelFile(ObjName, ModelsFolder))
 				return CachedModelPath;
 
 			SkipModels?.Add(ObjName);

--- a/EditorCore/EditorForm.cs
+++ b/EditorCore/EditorForm.cs
@@ -386,7 +386,7 @@ namespace EditorCore
 			string CachedModelPath = $"{ModelsFolder}\\{ObjName}.obj";
 			if (render.ImportedModels.ContainsKey(CachedModelPath) || //The model has aready been loaded or has been converted
 				File.Exists(CachedModelPath) ||
-				GameModule.ConvertModelFile(ObjName, ModelsFolder))
+				(GameModule.ConvertModelFile(ObjName, ModelsFolder) && File.Exists(CachedModelPath)))
 				return CachedModelPath;
 
 			SkipModels?.Add(ObjName);

--- a/FileFormatPlugins/BfresLib/BFRES.cs
+++ b/FileFormatPlugins/BfresLib/BFRES.cs
@@ -173,6 +173,8 @@ namespace Smash_Forge
                     };
                     int NextFMDL = f.pos();
 
+                    model.name = fmdl_info.name;
+
                     //Models.Nodes.Add(fmdl_info.name);
                     //   //Console.WriteLine($" Name {fmdl_info.name} eofString {fmdl_info.eofString} fsklOff {fmdl_info.fsklOff}");
                     //  //Console.WriteLine(fmdl_info.fvtxCount);
@@ -746,6 +748,7 @@ namespace Smash_Forge
 
         public class FMDL_Model
         {
+            public string name;
             public List<Mesh> poly = new List<Mesh>();
             public bool isVisible = true;
             public int[] Node_Array;

--- a/FileFormatPlugins/BfresLib/BfresConverter.cs
+++ b/FileFormatPlugins/BfresLib/BfresConverter.cs
@@ -17,14 +17,20 @@ namespace BfresLib
 {
     public class BfresConverter
     {
-
-        public static bool Convert(byte[] bfres, string outDir)
+		/// <summary>
+		/// Exports all models from the target bfres to the selected folder.
+		/// Returns array with the converted file names, it's NULL if no models were converted
+		/// </summary>
+		/// <param name="bfres">Source brfs</param>
+		/// <param name="outDir">Target directory</param>
+		/// <returns></returns>
+		public static string[] Convert(byte[] bfres, string outDir)
         {
-            if (bfres == null) return false;
+            if (bfres == null) return null;
             BFRES s = new BFRES();
             s.Read(bfres);
             Export(outDir, s);
-			bool res = s.models.Count != 0;
+			var res = s.models.Count == 0 ? null : s.models.Select(x => x.name).ToArray();
 			s = null;
             GC.Collect();
 			return res;
@@ -169,7 +175,7 @@ namespace BfresLib
                 {
                     Console.WriteLine("FAILED texture " + Tex.Name);
 #if DEBUG
-                    Debugger.Break();
+                    //Debugger.Break();
 #endif
                 }
 #if !FIRST_MIPMAP_ONLY


### PR DESCRIPTION
Splatoon 2 BFRES can have multiple FMDLs, so all models should be exported. I don't *think* this breaks existing extensions, but I'm not 100% sure.